### PR TITLE
bugfix (commonUtils) : HTML 태그가 삭제되지 않은 버그 수정

### DIFF
--- a/src/utils/commonUtils.js
+++ b/src/utils/commonUtils.js
@@ -39,15 +39,18 @@ export function normalizeStringProperties(sourceObject) {
   @returns 디코딩된 문자열
 */
 export function sanitizeAndDecodeHtmlEntity(string) {
-  return sanitizeHtml(string, {
-    allowedTags: []
-  })
+  //트러블슈팅 먼저 HTML엔티티를 변환하고 이후에 HTML태그를 제거해야한다.
+  const htmlEntityDecoded = string
     .replace(/&gt;/g, '>')
     .replace(/&lt;/g, '<')
     .replace(/&nbsp;/g, ' ')
     .replace(/&.*?;/g, '');
 
-  //todo: html sanitizer 추가
+  const sanitized = sanitizeHtml(htmlEntityDecoded, {
+    allowedTags: []
+  });
+
+  return sanitized;
 }
 
 /**


### PR DESCRIPTION
원인: 지금까지 고려한 케이스는 <span>전시제목</span> 등의 케이스였습니다.
  그런데 새로운 케이스 &lt;span&gt;전시제목&lt;/span&gt;가 발견되어
  제대로 내용이 가공되지 않는 상황이 생겼습니다.

  이를 해결하기 위해 먼저 &lt; 등의 HTML 엔티티를 디코딩하여
  <span>전시제목</span>의 형태로 바꾸어준후 sanitize를 적용했습니다.